### PR TITLE
Add resource to prompt engineering

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ An awesome list for collecting awesome lists related to prompt engineering.
 - [awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) - A curated list of awesome .cursorrules files
 - [Prompt 编写模式：如何将思维框架赋予机器](https://github.com/prompt-engineering/prompt-patterns) - 一份关于如何编写优秀的 prompt 的指南，包括一些常用的编写模式和技巧。
 - [免费 Prompt Engineering 教程](https://github.com/thinkingjimmy/Learning-Prompt) - 一个免费的 Prompt Engineering 教程，提供从入门到高级的学习资料和案例分析。
+- [God Tier Prompts](https://www.godtierprompts.com) - A community-driven leaderboard where the best prompts rise to the top.
 
 ### Other
 


### PR DESCRIPTION
Adding [God Tier Prompts](https://www.godtierprompts.com) to the prompt engineering section. A new AI prompt leaderboard, where everyone shares their prompts and the best rise to the top.
